### PR TITLE
Feature 1: Validacion completa al crear reserva

### DIFF
--- a/RoomBookingApi.Tests/ReservationServiceTests.cs
+++ b/RoomBookingApi.Tests/ReservationServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using RoomBookingApi.Data;
+using RoomBookingApi.Domain;
 using RoomBookingApi.Services;
 
 namespace RoomBookingApi.Tests;
@@ -10,26 +11,27 @@ public class ReservationServiceTests
     [TestMethod]
     public async Task CreateAsync_HappyPath_PersistsReservationAndReturnsSuccess()
     {
-        var dbName = $"reservation-service-{Guid.NewGuid()}";
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(dbName)
-            .Options;
-        await using var dbContext = new AppDbContext(options);
+        await using var dbContext = CreateDbContext();
+        var user = new User { Name = "Ana", Email = "ana@test.com" };
+        var room = new Room { Name = "Sala A", Capacity = 8, IsActive = true };
+        dbContext.Users.Add(user);
+        dbContext.Rooms.Add(room);
+        await dbContext.SaveChangesAsync();
 
         var fixedNow = new DateTime(2026, 4, 22, 12, 0, 0, DateTimeKind.Utc);
         var service = new ReservationService(dbContext, () => fixedNow);
         var startUtc = new DateTime(2026, 4, 23, 9, 0, 0, DateTimeKind.Utc);
         var endUtc = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc);
 
-        var result = await service.CreateAsync(new ReservationCreateCommand(1, 2, startUtc, endUtc));
+        var result = await service.CreateAsync(new ReservationCreateCommand(user.Id, room.Id, startUtc, endUtc));
 
         Assert.AreEqual(ReservationCreateStatus.Success, result.Status);
         Assert.IsNotNull(result.Reservation);
 
         var created = result.Reservation!;
         Assert.IsTrue(created.Id > 0);
-        Assert.AreEqual(1, created.UserId);
-        Assert.AreEqual(2, created.RoomId);
+        Assert.AreEqual(user.Id, created.UserId);
+        Assert.AreEqual(room.Id, created.RoomId);
         Assert.AreEqual(startUtc, created.StartUtc);
         Assert.AreEqual(endUtc, created.EndUtc);
         Assert.AreEqual(fixedNow, created.CreatedAtUtc);
@@ -37,5 +39,184 @@ public class ReservationServiceTests
         var persisted = await dbContext.Reservations.SingleAsync();
         Assert.AreEqual(created.Id, persisted.Id);
         Assert.AreEqual(created.CreatedAtUtc, persisted.CreatedAtUtc);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenTimestampsAreNotUtc_ReturnsInvalid()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = new ReservationService(dbContext);
+
+        var start = new DateTime(2026, 4, 23, 9, 0, 0, DateTimeKind.Unspecified);
+        var end = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc);
+
+        var result = await service.CreateAsync(new ReservationCreateCommand(1, 1, start, end));
+
+        Assert.AreEqual(ReservationCreateStatus.Invalid, result.Status);
+        Assert.AreEqual("StartUtc and EndUtc must be UTC.", result.Message);
+        Assert.AreEqual(0, await dbContext.Reservations.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenStartIsNotBeforeEnd_ReturnsInvalid()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = new ReservationService(dbContext);
+        var start = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc);
+
+        var result = await service.CreateAsync(new ReservationCreateCommand(1, 1, start, end));
+
+        Assert.AreEqual(ReservationCreateStatus.Invalid, result.Status);
+        Assert.AreEqual("StartUtc must be earlier than EndUtc.", result.Message);
+        Assert.AreEqual(0, await dbContext.Reservations.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenDurationIsLessThan30Minutes_ReturnsInvalid()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = new ReservationService(dbContext);
+        var start = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 4, 23, 10, 29, 0, DateTimeKind.Utc);
+
+        var result = await service.CreateAsync(new ReservationCreateCommand(1, 1, start, end));
+
+        Assert.AreEqual(ReservationCreateStatus.Invalid, result.Status);
+        Assert.AreEqual("Reservation must be at least 30 minutes long.", result.Message);
+        Assert.AreEqual(0, await dbContext.Reservations.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenUserDoesNotExist_ReturnsNotFound()
+    {
+        await using var dbContext = CreateDbContext();
+        var room = new Room { Name = "Sala A", Capacity = 8, IsActive = true };
+        dbContext.Rooms.Add(room);
+        await dbContext.SaveChangesAsync();
+
+        var service = new ReservationService(dbContext);
+        var start = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 4, 23, 10, 30, 0, DateTimeKind.Utc);
+
+        var result = await service.CreateAsync(new ReservationCreateCommand(999, room.Id, start, end));
+
+        Assert.AreEqual(ReservationCreateStatus.NotFound, result.Status);
+        Assert.AreEqual("User not found.", result.Message);
+        Assert.AreEqual(0, await dbContext.Reservations.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenRoomDoesNotExist_ReturnsNotFound()
+    {
+        await using var dbContext = CreateDbContext();
+        var user = new User { Name = "Ana", Email = "ana@test.com" };
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        var service = new ReservationService(dbContext);
+        var start = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 4, 23, 10, 30, 0, DateTimeKind.Utc);
+
+        var result = await service.CreateAsync(new ReservationCreateCommand(user.Id, 999, start, end));
+
+        Assert.AreEqual(ReservationCreateStatus.NotFound, result.Status);
+        Assert.AreEqual("Room not found.", result.Message);
+        Assert.AreEqual(0, await dbContext.Reservations.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenRoomIsInactive_ReturnsInvalid()
+    {
+        await using var dbContext = CreateDbContext();
+        var user = new User { Name = "Ana", Email = "ana@test.com" };
+        var room = new Room { Name = "Sala Legacy", Capacity = 4, IsActive = false };
+        dbContext.Users.Add(user);
+        dbContext.Rooms.Add(room);
+        await dbContext.SaveChangesAsync();
+
+        var service = new ReservationService(dbContext);
+        var start = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 4, 23, 10, 30, 0, DateTimeKind.Utc);
+
+        var result = await service.CreateAsync(new ReservationCreateCommand(user.Id, room.Id, start, end));
+
+        Assert.AreEqual(ReservationCreateStatus.Invalid, result.Status);
+        Assert.AreEqual("Room is inactive.", result.Message);
+        Assert.AreEqual(0, await dbContext.Reservations.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenTimeRangeOverlaps_ReturnsConflict()
+    {
+        await using var dbContext = CreateDbContext();
+        var user = new User { Name = "Ana", Email = "ana@test.com" };
+        var room = new Room { Name = "Sala A", Capacity = 8, IsActive = true };
+        dbContext.Users.Add(user);
+        dbContext.Rooms.Add(room);
+        await dbContext.SaveChangesAsync();
+
+        dbContext.Reservations.Add(new Reservation
+        {
+            UserId = user.Id,
+            RoomId = room.Id,
+            StartUtc = new DateTime(2026, 4, 23, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc),
+            CreatedAtUtc = new DateTime(2026, 4, 22, 12, 0, 0, DateTimeKind.Utc)
+        });
+        await dbContext.SaveChangesAsync();
+
+        var service = new ReservationService(dbContext);
+        var result = await service.CreateAsync(new ReservationCreateCommand(
+            user.Id,
+            room.Id,
+            new DateTime(2026, 4, 23, 9, 30, 0, DateTimeKind.Utc),
+            new DateTime(2026, 4, 23, 10, 30, 0, DateTimeKind.Utc)));
+
+        Assert.AreEqual(ReservationCreateStatus.Conflict, result.Status);
+        Assert.AreEqual("Room is already reserved for the selected time range.", result.Message);
+        Assert.AreEqual(1, await dbContext.Reservations.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenBackToBackWithExistingReservation_ReturnsSuccess()
+    {
+        await using var dbContext = CreateDbContext();
+        var user = new User { Name = "Ana", Email = "ana@test.com" };
+        var room = new Room { Name = "Sala A", Capacity = 8, IsActive = true };
+        dbContext.Users.Add(user);
+        dbContext.Rooms.Add(room);
+        await dbContext.SaveChangesAsync();
+
+        dbContext.Reservations.Add(new Reservation
+        {
+            UserId = user.Id,
+            RoomId = room.Id,
+            StartUtc = new DateTime(2026, 4, 23, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc),
+            CreatedAtUtc = new DateTime(2026, 4, 22, 12, 0, 0, DateTimeKind.Utc)
+        });
+        await dbContext.SaveChangesAsync();
+
+        var service = new ReservationService(dbContext);
+        var result = await service.CreateAsync(new ReservationCreateCommand(
+            user.Id,
+            room.Id,
+            new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 4, 23, 10, 30, 0, DateTimeKind.Utc)));
+
+        Assert.AreEqual(ReservationCreateStatus.Success, result.Status);
+        Assert.IsNotNull(result.Reservation);
+        Assert.AreEqual(2, await dbContext.Reservations.CountAsync());
+    }
+
+    private static AppDbContext CreateDbContext()
+    {
+        var dbName = $"reservation-service-{Guid.NewGuid()}";
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+
+        return new AppDbContext(options);
     }
 }

--- a/RoomBookingApi.Tests/ReservationsControllerTests.cs
+++ b/RoomBookingApi.Tests/ReservationsControllerTests.cs
@@ -59,6 +59,68 @@ public class ReservationsControllerTests
         Assert.AreEqual(createdAtUtc, dto.CreatedAtUtc);
     }
 
+    [TestMethod]
+    public async Task Create_WhenServiceReturnsInvalid_ReturnsBadRequestWithExactMessage()
+    {
+        const string errorMessage = "StartUtc and EndUtc must be UTC.";
+        var service = new FakeReservationService
+        {
+            CreateResult = ReservationCreateResult.Invalid(errorMessage)
+        };
+
+        var controller = new ReservationsController(service);
+        var actionResult = await controller.Create(CreateRequest());
+
+        var badRequest = actionResult.Result as BadRequestObjectResult;
+        Assert.IsNotNull(badRequest);
+        Assert.AreEqual(errorMessage, badRequest.Value);
+    }
+
+    [TestMethod]
+    public async Task Create_WhenServiceReturnsNotFound_ReturnsNotFoundWithExactMessage()
+    {
+        const string errorMessage = "User not found.";
+        var service = new FakeReservationService
+        {
+            CreateResult = ReservationCreateResult.NotFound(errorMessage)
+        };
+
+        var controller = new ReservationsController(service);
+        var actionResult = await controller.Create(CreateRequest());
+
+        var notFound = actionResult.Result as NotFoundObjectResult;
+        Assert.IsNotNull(notFound);
+        Assert.AreEqual(errorMessage, notFound.Value);
+    }
+
+    [TestMethod]
+    public async Task Create_WhenServiceReturnsConflict_ReturnsConflictWithExactMessage()
+    {
+        const string errorMessage = "Room is already reserved for the selected time range.";
+        var service = new FakeReservationService
+        {
+            CreateResult = ReservationCreateResult.Conflict(errorMessage)
+        };
+
+        var controller = new ReservationsController(service);
+        var actionResult = await controller.Create(CreateRequest());
+
+        var conflict = actionResult.Result as ConflictObjectResult;
+        Assert.IsNotNull(conflict);
+        Assert.AreEqual(errorMessage, conflict.Value);
+    }
+
+    private static CreateReservationDto CreateRequest()
+    {
+        return new CreateReservationDto
+        {
+            UserId = 1,
+            RoomId = 2,
+            StartUtc = new DateTime(2026, 4, 23, 9, 0, 0, DateTimeKind.Utc),
+            EndUtc = new DateTime(2026, 4, 23, 10, 0, 0, DateTimeKind.Utc)
+        };
+    }
+
     private sealed class FakeReservationService : IReservationService
     {
         public ReservationCreateResult CreateResult { get; set; } = ReservationCreateResult.Invalid("Not configured.");

--- a/RoomBookingApi/Services/ReservationService.cs
+++ b/RoomBookingApi/Services/ReservationService.cs
@@ -1,5 +1,6 @@
 using RoomBookingApi.Data;
 using RoomBookingApi.Domain;
+using Microsoft.EntityFrameworkCore;
 
 namespace RoomBookingApi.Services;
 
@@ -11,8 +12,59 @@ public interface IReservationService
 
 public sealed class ReservationService(AppDbContext dbContext, Func<DateTime>? utcNow = null) : IReservationService
 {
+    private const int MinimumReservationMinutes = 30;
+    private const string UtcValidationMessage = "StartUtc and EndUtc must be UTC.";
+    private const string StartBeforeEndValidationMessage = "StartUtc must be earlier than EndUtc.";
+    private const string MinimumDurationValidationMessage = "Reservation must be at least 30 minutes long.";
+    private const string UserNotFoundMessage = "User not found.";
+    private const string RoomNotFoundMessage = "Room not found.";
+    private const string RoomInactiveMessage = "Room is inactive.";
+    private const string RoomConflictMessage = "Room is already reserved for the selected time range.";
+
     public async Task<ReservationCreateResult> CreateAsync(ReservationCreateCommand command)
     {
+        if (command.StartUtc.Kind != DateTimeKind.Utc || command.EndUtc.Kind != DateTimeKind.Utc)
+        {
+            return ReservationCreateResult.Invalid(UtcValidationMessage);
+        }
+
+        if (command.StartUtc >= command.EndUtc)
+        {
+            return ReservationCreateResult.Invalid(StartBeforeEndValidationMessage);
+        }
+
+        if ((command.EndUtc - command.StartUtc) < TimeSpan.FromMinutes(MinimumReservationMinutes))
+        {
+            return ReservationCreateResult.Invalid(MinimumDurationValidationMessage);
+        }
+
+        var userExists = await dbContext.Users.AnyAsync(u => u.Id == command.UserId);
+        if (!userExists)
+        {
+            return ReservationCreateResult.NotFound(UserNotFoundMessage);
+        }
+
+        var room = await dbContext.Rooms.FindAsync(command.RoomId);
+        if (room is null)
+        {
+            return ReservationCreateResult.NotFound(RoomNotFoundMessage);
+        }
+
+        if (!room.IsActive)
+        {
+            return ReservationCreateResult.Invalid(RoomInactiveMessage);
+        }
+
+        var hasConflict = await dbContext.Reservations.AnyAsync(r =>
+            r.RoomId == command.RoomId &&
+            r.StartUtc < command.EndUtc &&
+            r.EndUtc > command.StartUtc);
+
+        if (hasConflict)
+        {
+            return ReservationCreateResult.Conflict(RoomConflictMessage);
+        }
+
         var reservation = new Reservation
         {
             UserId = command.UserId,


### PR DESCRIPTION
﻿## Feature elegida
Feature 1 - Validacion completa al crear reserva.

## Issue del PRD (Fase 2)
- #14

## Issues de implementacion (Fase 3)
- #15
- #16
- #17
- #18

## Resumen de implementacion
- Se agregaron validaciones de payload en creacion de reserva: UTC obligatorio, inicio menor a fin y duracion minima de 30 minutos.
- Se agregaron validaciones de referencias: usuario existente, sala existente y sala activa.
- Se implemento deteccion de conflictos en la misma sala con intervalos semiabiertos [start, end), permitiendo back-to-back.
- Se mantuvo contrato HTTP del controller: Invalid -> 400, NotFound -> 404, Conflict -> 409.
- Se mantuvo body de error como string plano con mensajes exactos y estables.

## Reflexion
En el grill-me descubrimos que definir explicitamente los bordes de conflicto era mas importante de lo que parecia al inicio.
Antes del proceso, no habiamos fijado con precision que pasaba cuando una reserva terminaba exactamente al inicio de otra.
Tambien no habiamos considerado el impacto de exigir UTC de forma estricta para evitar ambiguedades de zona horaria.
El orden de validaciones cambio nuestro plan original porque nos obligo a separar reglas de payload y reglas de negocio referencial.
Definir mensajes exactos nos ayudo a convertir decisiones funcionales en contratos verificables por tests.
El plan por issues hizo mas claro el avance incremental y redujo retrabajo entre etapas.
La proxima vez formalizariamos estos contratos desde el primer borrador del feature para llegar antes a implementacion estable.

## Validacion
- dotnet test RoomBooking.sln
- Resultado: 13/13 tests en verde.
